### PR TITLE
fixed schema in WeatherMapDataSource_cactithold.php to use new fields.

### DIFF
--- a/lib/datasources/WeatherMapDataSource_cactithold.php
+++ b/lib/datasources/WeatherMapDataSource_cactithold.php
@@ -106,10 +106,10 @@ $thold_present = false;
 			// use target aggregation to build these up into a 'badness' percentage
 			// takes the same two values that are visible in thold's own URLs (the actual thold ID isn't shown anywhere)
 			
-			$rra_id = intval($matches[1]);
-			$data_id = intval($matches[2]);
+			$local_data_id = intval($matches[1]);
+			$data_template_rrd_id = intval($matches[2]);
 			
-			$SQL2 = "select thold_alert from thold_data where rra_id=$rra_id and data_id=$data_id and thold_enabled='on'";
+			$SQL2 = "select thold_alert from thold_data where local_data_id=$local_data_id and data_template_rrd_id=$data_template_rrd_id and thold_enabled='on'";
 			$result = db_fetch_row($SQL2);
 			if(isset($result))
 			{
@@ -179,13 +179,13 @@ $thold_present = false;
 				wm_debug("CactiTHold ReadData: Checking threshold states for host $id\n");
 				$numthresh = 0;
 				$numfailing = 0;
-				$SQL2 = "select rra_id, data_id, thold_alert from thold_data,data_local where thold_data.rra_id=data_local.id and data_local.host_id=$id and thold_enabled='on'";
+				$SQL2 = "select local_data_id, data_template_rrd_id, thold_alert from thold_data,data_local where thold_data.local_data_id=data_local.id and data_local.host_id=$id and thold_enabled='on'";
 				# $result = db_fetch_row($SQL2);
 				$queryrows = db_fetch_assoc($SQL2);
 				if( is_array($queryrows) )
 				{
 					foreach ($queryrows as $th) {					
-						$desc = $th['rra_id']."/".$th['data_id'];
+						$desc = $th['local_data_id']."/".$th['data_template_rrd_id'];
 						$v = $th['thold_alert'];
 						$numthresh++;
 						if(intval($th['thold_alert']) > 0) 

--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -244,7 +244,7 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		$args[] = "graph";
 		$args[] = "/dev/null";
 		$args[] = "-f";
-		$args[] = "''";
+		$args[] = "'%s %lu %lu'";
 		$args[] = "--start";
 		$args[] = $start;
 		$args[] = "--end";


### PR DESCRIPTION
Updated field names in SQL statements and PHP local variables to reflect changed schema in thold_data table.

rra_id -> local_data_id
data_id -> data_template_rrd_id

This resolves error messages that were appearing in the Cacti log. This problem does not seem to occur if the thold plugin is not installed.

CMDPHP SQL Backtrace: (/poller.php[796]:api_plugin_hook(), /lib/plugins.php[74]:api_plugin_run_plugin_hook(), /lib/plugins.php[177]:weathermap_poller_bottom(), /plugins/weathermap/setup.php[778]:weathermap_run_maps(), /plugins/weathermap/lib/poller-common.php[195]:WeatherMap->ReadData(), /plugins/weathermap/lib/Weathermap.class.php[955]:WeatherMapDataSource_cactithold->ReadData(), /plugins/weathermap/lib/datasources/WeatherMapDataSource_cactithold.php[184]:db_fetch_assoc(), /lib/database.php[452]:db_fetch_assoc_prepared(), /lib/database.php[466]:db_execute_prepared()) 
CMDPHP ERROR: A DB Row Failed!, Error: Unknown column 'rra_id' in 'field list'

I have not tested if thold integration with Weathermap actually works. I only see that the SQL errors are now gone.