### PR TITLE
require cli_check.php in weathermap cli (resolves #134)

### DIFF
--- a/weathermap
+++ b/weathermap
@@ -6,6 +6,7 @@
 // http://www.network-weathermap.com/
 // Released under the MIT License
 require_once('Console/Getopt.php');
+require_once('../../include/cli_check.php');
 require_once('lib/WeatherMap.class.php');
 
 //$weathermap_debugging=true; 


### PR DESCRIPTION
Weathermap cli output errors referring to undefined function cacti_sizeof() without it.