### PR TITLE
Remove all uses of deprecated PHP function 'get_magic_quotes_gpc()'

### DIFF
--- a/lib/editor.actions.php
+++ b/lib/editor.actions.php
@@ -183,7 +183,7 @@ function setNodeConfig($mapfile) {
 	$map->ReadConfig($mapfile);
 
 	$node_name = get_nfilter_request_var('node_name');
-	$node_config = fix_gpc_string(get_nfilter_request_var('item_configtext'));
+	$node_config = get_nfilter_request_var('item_configtext');
 
 	if (isset($map->nodes[$node_name])) {
 		$map->nodes[$node_name]->config_override = $node_config;
@@ -210,7 +210,7 @@ function setLinkConfig($mapfile) {
 	$map->ReadConfig($mapfile);
 
 	$link_name = get_nfilter_request_var('link_name');
-	$link_config = fix_gpc_string(get_nfilter_request_var('item_configtext'));
+	$link_config = get_nfilter_request_var('item_configtext');
 
 	if (isset($map->links[$link_name])) {
 		$map->links[$link_name]->config_override = $link_config;

--- a/lib/editor.inc.php
+++ b/lib/editor.inc.php
@@ -45,24 +45,6 @@
  * All the functions used by the editor.
  */
 
-/** @function fix_gpc_string
-  *
-  * Take a string (that we got from $_REQUEST) and make it back to how the
-  * user TYPED it, regardless of whether magic_quotes_gpc is turned on or off.
-  *
-  * @param string $input String to fix
-  *
-  * @returns string Fixed string
-  *
-  */
-function fix_gpc_string($input) {
-	if (true == function_exists('get_magic_quotes_gpc') && 1 == get_magic_quotes_gpc()) {
-		$input = stripslashes($input);
-	}
-
-	return ($input);
-}
-
 function display_graphs() {
 	$sql_where  = '';
 	$sql_params = array();


### PR DESCRIPTION
Removes all uses of function 'get_magic_quotes_gpc()' that is deprecated in PHP 7.4 and removed in PHP 8.0.