### PR TITLE
Add create map and copy map functions to weathermap-cacti-plugin-mgmt.php

### DIFF
--- a/weathermap-cacti-plugin-mgmt.php
+++ b/weathermap-cacti-plugin-mgmt.php
@@ -1260,7 +1260,7 @@ function addmap_picker($show_all = false) {
 	print '<br/><br/>';
 
 	print 'Do you want to:<p>';
-	print '<ul><li>Create A New Map:<br>';
+	print '<ul><li>Create a new Weathermap Configuration File:<br>';
 	print '<form method="GET">';
 	print 'Named: <input type="text" name="mapname" size="20">';
 
@@ -1326,7 +1326,7 @@ function addmap_picker($show_all = false) {
 	    $errorstring = "NO DIRECTORY named $mapdir";
 	}
 
-	print '<br/></li><li>Create A New Map as a copy of an existing map:<br>';
+	print '<br/></li><li>Create a new Weathermap Configuration File as a copy of an existing Weathermap:<br>';
 	print '<form method="GET">';
 	print 'Named: <input type="text" name="mapname" size="20"> based on ';
 


### PR DESCRIPTION
This is an attempt to fix #144

Probably not perfect but should fix the missing create map and copy map function without too many changes.
I've included some part of the show_editor_startpage() functions from lib/editor.inc.php and lib/editor.actions.php, these functions may be later deleted to clean up old unused code if the direct access to weathermap-cacti-plugin-editor.php is deprecated in this only Cacti's plugin.

This also makes it clearer for users who want to add a new weathermap, the "+" button opened only a management of .conf file but did not allow in this same interface to add a new one from scratch, they had to go in another interface in the past. 
The duplicate function also don't allow to rename .conf so to keep a clear naming of all .conf it is not ideal, the copy function is better for that too.

![image](https://github.com/Cacti/plugin_weathermap/assets/4399512/2fb67057-da39-4b67-abc1-3dab14a5f9aa)
