### PR TITLE
Curvepoints fix causing plugin to be disabled

### DIFF
--- a/lib/WeatherMap.functions.php
+++ b/lib/WeatherMap.functions.php
@@ -814,11 +814,12 @@ function find_distance(&$pointarray, $distance) {
 /**
  * Give a list of key points, calculate a curve through them
  * return value is an array of triples (x,y,distance)
+ *
  * @param mixed $in_xarray
  * @param mixed $in_yarray
  * @param mixed $pointsperspan
  */
-function calc_curve(&$in_xarray, &$in_yarray,$pointsperspan = 32) {
+function calc_curve(&$in_xarray, &$in_yarray, $pointsperspan = 32) {
 	// search through the point list, for consecutive duplicate points
 	// (most common case will be a straight link with both NODEs at the same place, I think)
 	// strip those out, because they'll break the binary search/centre-point stuff
@@ -880,7 +881,7 @@ function calc_curve(&$in_xarray, &$in_yarray,$pointsperspan = 32) {
 		$curvepoints = $curvepoints + $newpoints;
 	}
 
-	return ($curvepoints);
+	return $curvepoints;
 }
 
 /**
@@ -888,11 +889,12 @@ function calc_curve(&$in_xarray, &$in_yarray,$pointsperspan = 32) {
  * return value is an array of triples (x,y,distance)
  * this is here to mirror the real 'curve' version when we're using angled VIAs
  * it means that all the stuff that expects an array of points with distances won't be upset.
+ *
  * @param mixed $in_xarray
  * @param mixed $in_yarray
  * @param mixed $pointsperspan
  */
-function calc_straight(&$in_xarray, &$in_yarray,$pointsperspan = 12) {
+function calc_straight(&$in_xarray, &$in_yarray, $pointsperspan = 12) {
 	// search through the point list, for consecutive duplicate points
 	// (most common case will be a straight link with both NODEs at the same place, I think)
 	// strip those out, because they'll break the binary search/centre-point stuff
@@ -948,9 +950,7 @@ function calc_straight(&$in_xarray, &$in_yarray,$pointsperspan = 12) {
 
 	$curvepoints[] = [$xarray[$npoints - 1], $yarray[$npoints - 1], $distance];
 
-//	print_r($curvepoints);
-
-	return ($curvepoints);
+	return $curvepoints;
 }
 
 function calc_arrowsize($width,&$map,$linkname) {

--- a/lib/WeatherMapLink.class.php
+++ b/lib/WeatherMapLink.class.php
@@ -118,7 +118,7 @@ class WeatherMapLink extends WeatherMapItem {
 
 	var $comments       = [];
 	var $bwlabelformats = [];
-	var $curvepoints;
+	var $curvepoints    = [];
 
 	var $labeloffset_in;
 	var $labeloffset_out;
@@ -242,7 +242,7 @@ class WeatherMapLink extends WeatherMapItem {
 	 * @param mixed $widths
 	 */
 	function DrawComments($image, $col, $widths) {
-		$curvepoints = &$this->curvepoints;
+		$curvepoints = $this->curvepoints;
 
 		$last = count($curvepoints) - 1;
 

--- a/lib/WeatherMapLink.class.php
+++ b/lib/WeatherMapLink.class.php
@@ -244,7 +244,7 @@ class WeatherMapLink extends WeatherMapItem {
 	function DrawComments($image, $col, $widths) {
 		$curvepoints = $this->curvepoints;
 
-		$last = count($curvepoints) - 1;
+		$last = cacti_count($curvepoints) - 1;
 
 		$totaldistance = $curvepoints[$last][2];
 
@@ -416,7 +416,7 @@ class WeatherMapLink extends WeatherMapItem {
 		$x2 += $dx;
 		$y2 += $dy;
 
-		if (($x1 == $x2) && ($y1 == $y2) && sizeof($this->vialist) == 0) {
+		if (($x1 == $x2) && ($y1 == $y2) && cacti_sizeof($this->vialist) == 0) {
 			wm_warn('Zero-length link ' . $this->name . ' skipped. [WMWARN45]');
 
 			return;
@@ -477,7 +477,7 @@ class WeatherMapLink extends WeatherMapItem {
 		}
 
 		// If there are no vias, treat this as a 2-point angled link, not curved
-		if (sizeof($this->vialist) == 0 || $this->viastyle == 'angled') {
+		if (cacti_sizeof($this->vialist) == 0 || $this->viastyle == 'angled') {
 			// Calculate the spine points - the actual not a curve really, but we
 			// need to create the array, and calculate the distance bits, otherwise
 			// things like bwlabels won't know where to go.
@@ -515,7 +515,7 @@ class WeatherMapLink extends WeatherMapItem {
 			$this->DrawComments($image,[$comment_colour_in, $comment_colour_out],[$link_in_width * 1.1, $link_out_width * 1.1]);
 		}
 
-		$curvelength = $this->curvepoints[count($this->curvepoints) - 1][2];
+		$curvelength = $this->curvepoints[cacti_count($this->curvepoints) - 1][2];
 
 		// figure out where the labels should be, and what the angle of the curve is at that point
 		[$q1_x, $q1_y, $junk, $q1_angle] = find_distance_coords_angle($this->curvepoints, ($this->labeloffset_out / 100) * $curvelength);
@@ -796,7 +796,7 @@ class WeatherMapLink extends WeatherMapItem {
 				$output .= EOL;
 			}
 
-			if (count($this->vialist) > 0) {
+			if (cacti_count($this->vialist) > 0) {
 				foreach ($this->vialist as $via) {
 					if (isset($via[2])) {
 						$output .= sprintf(TAB . 'VIA %s %d %d' . EOL, $via[2],$via[0], $via[1]);


### PR DESCRIPTION
This is an additional fix to #219 where the count function was failing due to the curvepoints variable not being a countable object, in other words, not being an array.  This error would be ignored in earlier versions of PHP.