### PR TITLE
fix(weathermap): correct 12 rendering and config logic bugs

### DIFF
--- a/lib/WeatherMap.class.php
+++ b/lib/WeatherMap.class.php
@@ -120,7 +120,7 @@ class WeatherMapDataSource {
 	//   itemtype and itemname may be used as part of the target (e.g. for TSV source line)
 	// function ReadData($targetstring, $configline, $itemtype, $itemname, $map) { return (array(-1,-1)); }
 	function ReadData($targetstring, &$map, &$item) {
-		return ([-1, -1]);
+		return ([-1, -1, 0]);
 	}
 
 	// pre-register a target + context, to allow a plugin to batch up queries to a slow database, or snmp for example

--- a/lib/WeatherMap.class.php
+++ b/lib/WeatherMap.class.php
@@ -1610,16 +1610,16 @@ class WeatherMap extends WeatherMapBase {
 
 		if (!is_none($this->colours['DEFAULT']['KEYBG'])) {
 			wimagefilledrectangle($scale_im, $box_left, $box_top, $box_right, $box_bottom,
-				$this->colours['DEFAULT']['KEYBG']['gdref1']);
+				$this->colours['DEFAULT']['KEYBG'][$scale_ref]);
 		}
 
 		if (!is_none($this->colours['DEFAULT']['KEYOUTLINE'])) {
 			wimagerectangle($scale_im, $box_left, $box_top, $box_right, $box_bottom,
-				$this->colours['DEFAULT']['KEYOUTLINE']['gdref1']);
+				$this->colours['DEFAULT']['KEYOUTLINE'][$scale_ref]);
 		}
 
 		$this->myimagestring($scale_im, $font, $scale_left - $scalefactor, $scale_top - $tileheight , $title,
-			$this->colours['DEFAULT']['KEYTEXT']['gdref1']
+			$this->colours['DEFAULT']['KEYTEXT'][$scale_ref]
 		);
 
 		$updown = 1;
@@ -1749,8 +1749,6 @@ class WeatherMap extends WeatherMapBase {
 
 			$boxx = $x;
 			$boxy = $y;
-			$boxx = 0;
-			$boxy = 0;
 
 			// allow for X11-style negative positioning
 			if ($boxx < 0) {
@@ -2143,7 +2141,7 @@ class WeatherMap extends WeatherMapBase {
 		// if it isn't, it's the filename
 		$lines = [];
 
-		if (strchr($input, "\n") != false || strchr($input, "\r") != false) {
+		if (strchr($input, "\n") !== false || strchr($input, "\r") !== false) {
 			wm_debug('ReadConfig Detected that this is a config fragment.');
 
 			// strip out any Windows line-endings that have gotten in here
@@ -3536,7 +3534,7 @@ class WeatherMap extends WeatherMapBase {
 			if (file_exists($this->configfile)) {
 				$this->cachefile_version = crc32(file_get_contents($this->configfile));
 			} else {
-				wm_warn('Failed to find configuration file: ' . $this->configFile);
+				wm_warn('Failed to find configuration file: ' . $this->configfile);
 			}
 		}
 
@@ -4492,8 +4490,6 @@ class WeatherMap extends WeatherMapBase {
 	}
 
 	function LoadCoverage($file) {
-		// ToDo - Why the return?
-		return 0;
 		$i = 0;
 
 		$fd = fopen($file, 'r');

--- a/lib/WeatherMap.class.php
+++ b/lib/WeatherMap.class.php
@@ -1785,9 +1785,11 @@ class WeatherMap extends WeatherMapBase {
 				);
 			}
 
-			$this->myimagestring($scale_im, $font, 4, 4 + $tileheight, $title,
-				$this->colours['DEFAULT']['KEYTEXT'][$scale_ref]
-			);
+			if (isset($this->colours['DEFAULT']['KEYTEXT'][$scale_ref])) {
+				$this->myimagestring($scale_im, $font, 4, 4 + $tileheight, $title,
+					$this->colours['DEFAULT']['KEYTEXT'][$scale_ref]
+				);
+			}
 
 			$i = 1;
 
@@ -4532,7 +4534,15 @@ class WeatherMap extends WeatherMapBase {
 	function SaveCoverage($file) {
 		$i = 0;
 
-		$fd = fopen($file, 'w+');
+		$dir  = realpath(dirname($file));
+		$base = defined('CACTI_PATH_BASE') ? realpath(CACTI_PATH_BASE) : realpath(dirname(dirname(__FILE__)));
+
+		if ($dir === false || $base === false || strpos($dir . DIRECTORY_SEPARATOR, $base . DIRECTORY_SEPARATOR) !== 0) {
+			return;
+		}
+
+		$safe = $dir . DIRECTORY_SEPARATOR . basename($file);
+		$fd   = fopen($safe, 'w+');
 
 		foreach ($this->coverage as $key=>$val) {
 			fputs($fd, "$val\t$key\n");

--- a/lib/WeatherMap.class.php
+++ b/lib/WeatherMap.class.php
@@ -1608,19 +1608,21 @@ class WeatherMap extends WeatherMapBase {
 
 		$this->AllocateScaleColours($scale_im,$scale_ref);
 
-		if (!is_none($this->colours['DEFAULT']['KEYBG'])) {
+		if (!is_none($this->colours['DEFAULT']['KEYBG']) && isset($this->colours['DEFAULT']['KEYBG'][$scale_ref])) {
 			wimagefilledrectangle($scale_im, $box_left, $box_top, $box_right, $box_bottom,
 				$this->colours['DEFAULT']['KEYBG'][$scale_ref]);
 		}
 
-		if (!is_none($this->colours['DEFAULT']['KEYOUTLINE'])) {
+		if (!is_none($this->colours['DEFAULT']['KEYOUTLINE']) && isset($this->colours['DEFAULT']['KEYOUTLINE'][$scale_ref])) {
 			wimagerectangle($scale_im, $box_left, $box_top, $box_right, $box_bottom,
 				$this->colours['DEFAULT']['KEYOUTLINE'][$scale_ref]);
 		}
 
-		$this->myimagestring($scale_im, $font, $scale_left - $scalefactor, $scale_top - $tileheight , $title,
-			$this->colours['DEFAULT']['KEYTEXT'][$scale_ref]
-		);
+		if (isset($this->colours['DEFAULT']['KEYTEXT'][$scale_ref])) {
+			$this->myimagestring($scale_im, $font, $scale_left - $scalefactor, $scale_top - $tileheight , $title,
+				$this->colours['DEFAULT']['KEYTEXT'][$scale_ref]
+			);
+		}
 
 		$updown = 1;
 
@@ -4492,14 +4494,27 @@ class WeatherMap extends WeatherMapBase {
 	function LoadCoverage($file) {
 		$i = 0;
 
-		$fd = fopen($file, 'r');
+		$real = realpath($file);
+		$base = defined('CACTI_PATH_BASE') ? realpath(CACTI_PATH_BASE) : realpath(dirname(dirname(__FILE__)));
+
+		if ($real === false || $base === false || strpos($real, $base . DIRECTORY_SEPARATOR) !== 0) {
+			return;
+		}
+
+		$fd = fopen($real, 'r');
 
 		if (is_resource($fd)) {
 			while (!feof($fd)) {
-				$line = fgets($fd,1024);
+				$line = fgets($fd, 1024);
 				$line = trim($line);
 
-				[$val,$key] = explode("\t",$line);
+				$parts = explode("\t", $line);
+
+				if (count($parts) < 2) {
+					continue;
+				}
+
+				[$val, $key] = $parts;
 
 				if ($key != '') {
 					$this->coverage[$key] = $val;

--- a/lib/WeatherMap.class.php
+++ b/lib/WeatherMap.class.php
@@ -1774,18 +1774,18 @@ class WeatherMap extends WeatherMapBase {
 			$this->AllocateScaleColours($scale_im,$scale_ref);
 
 			if (!is_none($this->colours['DEFAULT']['KEYBG'])) {
-				wimagefilledrectangle($scale_im, $boxx, $boxy, $boxx + $boxwidth, $boxy + $boxheight,
+				wimagefilledrectangle($scale_im, 0, 0, $boxwidth, $boxheight,
 					$this->colours['DEFAULT']['KEYBG'][$scale_ref]
 				);
 			}
 
 			if (!is_none($this->colours['DEFAULT']['KEYOUTLINE'])) {
-				wimagerectangle($scale_im, $boxx, $boxy, $boxx + $boxwidth, $boxy + $boxheight,
+				wimagerectangle($scale_im, 0, 0, $boxwidth, $boxheight,
 					$this->colours['DEFAULT']['KEYOUTLINE'][$scale_ref]
 				);
 			}
 
-			$this->myimagestring($scale_im, $font, $boxx + 4, $boxy + 4 + $tileheight, $title,
+			$this->myimagestring($scale_im, $font, 4, 4 + $tileheight, $title,
 				$this->colours['DEFAULT']['KEYTEXT'][$scale_ref]
 			);
 
@@ -1800,8 +1800,8 @@ class WeatherMap extends WeatherMapBase {
 
 					//  debug("$i: drawing\n");
 					if (($hide_zero == 0) || $colour['key'] != '0_0') {
-						$y = $boxy + $tilespacing * $i + 8;
-						$x = $boxx + 6;
+						$y = $tilespacing * $i + 8;
+						$x = 6;
 
 						$fudgefactor = 0;
 

--- a/lib/WeatherMap.functions.php
+++ b/lib/WeatherMap.functions.php
@@ -414,15 +414,15 @@ function is_none($arr) {
 }
 
 function render_colour($col) {
-	if (($col[0] == -1) && ($col[1] == -1) && ($col[1] == -1)) {
+	if (($col[0] == -1) && ($col[1] == -1) && ($col[2] == -1)) {
 		return 'none';
 	}
 
-	if (($col[0] == -2) && ($col[1] == -2) && ($col[1] == -2)) {
+	if (($col[0] == -2) && ($col[1] == -2) && ($col[2] == -2)) {
 		return 'copy';
 	}
 
-	if (($col[0] == -3) && ($col[1] == -3) && ($col[1] == -3)) {
+	if (($col[0] == -3) && ($col[1] == -3) && ($col[2] == -3)) {
 		return 'contrast';
 	} else {
 		return sprintf('%d %d %d', $col[0], $col[1], $col[2]);

--- a/lib/WeatherMap.functions.php
+++ b/lib/WeatherMap.functions.php
@@ -242,14 +242,14 @@ function mysprintf($format, $value, $kilo = 1000) {
 		wm_debug("KMGT formatting $value with $spec.");
 
 		$result = nice_scalar($value, $kilo, $places);
-		$output = preg_replace('/%' . $spec . 'k/', $format, $result);
+		$output = preg_replace('/%' . $spec . 'k/', $result, $format);
 	} elseif (preg_match('/%(-*)(\d*)([Tt])/', $format, $matches)) {
 		$spec      = $matches[3];
 		$precision = ($matches[2] == '' ? 10 : intval($matches[2]));
 		$joinchar  = ' ';
 
 		if ($matches[1] == '-') {
-			$joinchar = ' ';
+			$joinchar = '-';
 		}
 
 		// special formatting for time_t (t) and SNMP TimeTicks (T)
@@ -878,7 +878,7 @@ function calc_curve(&$in_xarray, &$in_yarray, $pointsperspan = 32) {
 			$yarray[$i], $xarray[$i + 1], $yarray[$i + 1], $xarray[$i + 2],
 			$yarray[$i + 2], $xarray[$i + 3], $yarray[$i + 3]);
 
-		$curvepoints = $curvepoints + $newpoints;
+		$curvepoints = array_merge($curvepoints, $newpoints);
 	}
 
 	return $curvepoints;

--- a/lib/WeatherMap.functions.php
+++ b/lib/WeatherMap.functions.php
@@ -242,7 +242,7 @@ function mysprintf($format, $value, $kilo = 1000) {
 		wm_debug("KMGT formatting $value with $spec.");
 
 		$result = nice_scalar($value, $kilo, $places);
-		$output = preg_replace_callback('/%' . $spec . 'k/', function() use ($result) { return $result; }, $format);
+		$output = preg_replace_callback('/%' . preg_quote($spec, '/') . 'k/', function() use ($result) { return $result; }, $format);
 	} elseif (preg_match('/%(-*)(\d*)([Tt])/', $format, $matches)) {
 		$spec      = $matches[3];
 		$precision = ($matches[2] == '' ? 10 : intval($matches[2]));
@@ -878,7 +878,7 @@ function calc_curve(&$in_xarray, &$in_yarray, $pointsperspan = 32) {
 			$yarray[$i], $xarray[$i + 1], $yarray[$i + 1], $xarray[$i + 2],
 			$yarray[$i + 2], $xarray[$i + 3], $yarray[$i + 3]);
 
-		$curvepoints = array_merge($curvepoints, $newpoints);
+		$curvepoints = array_merge($curvepoints, array_slice($newpoints, 1));
 	}
 
 	return $curvepoints;

--- a/lib/WeatherMap.functions.php
+++ b/lib/WeatherMap.functions.php
@@ -242,7 +242,7 @@ function mysprintf($format, $value, $kilo = 1000) {
 		wm_debug("KMGT formatting $value with $spec.");
 
 		$result = nice_scalar($value, $kilo, $places);
-		$output = preg_replace('/%' . $spec . 'k/', $result, $format);
+		$output = preg_replace_callback('/%' . $spec . 'k/', function() use ($result) { return $result; }, $format);
 	} elseif (preg_match('/%(-*)(\d*)([Tt])/', $format, $matches)) {
 		$spec      = $matches[3];
 		$precision = ($matches[2] == '' ? 10 : intval($matches[2]));

--- a/lib/WeatherMapLink.class.php
+++ b/lib/WeatherMapLink.class.php
@@ -860,8 +860,8 @@ class WeatherMapLink extends WeatherMapItem {
 		$js .= 'bw_out:' . js_escape($this->max_bandwidth_out_cfg) . ', ';
 
 		$js .= 'name:' . js_escape($this->name) . ', ';
-		$js .= 'overlibwidth:"' . $this->overlibheight . '", ';
-		$js .= 'overlibheight:"' . $this->overlibwidth . '", ';
+		$js .= 'overlibwidth:"' . $this->overlibwidth . '", ';
+		$js .= 'overlibheight:"' . $this->overlibheight . '", ';
 		$js .= 'overlibcaption:' . js_escape($this->overlibcaption[IN]) . ', ';
 
 		$js .= 'commentin:' . js_escape($this->comments[IN]) . ', ';
@@ -910,8 +910,8 @@ class WeatherMapLink extends WeatherMapItem {
 			$js .= '"bw_out":' . js_escape($this->max_bandwidth_out_cfg) . ', ';
 
 			$js .= '"name":' . js_escape($this->name) . ', ';
-			$js .= '"overlibwidth":"' . $this->overlibheight . '", ';
-			$js .= '"overlibheight":"' . $this->overlibwidth . '", ';
+			$js .= '"overlibwidth":"' . $this->overlibwidth . '", ';
+			$js .= '"overlibheight":"' . $this->overlibheight . '", ';
 			$js .= '"overlibcaption":' . js_escape($this->overlibcaption) . ', ';
 		}
 

--- a/lib/WeatherMapNode.class.php
+++ b/lib/WeatherMapNode.class.php
@@ -977,8 +977,8 @@ class WeatherMapNode extends WeatherMapItem {
 		$js .= 'infourl:' . js_escape($this->infourl[IN]) . ', ';
 		$js .= 'overlibcaption:' . js_escape($this->overlibcaption[IN]) . ', ';
 		$js .= 'overliburl:' . js_escape(join(' ',$this->overliburl[IN])) . ', ';
-		$js .= 'overlibwidth:' . $this->overlibheight . ', ';
-		$js .= 'overlibheight:' . $this->overlibwidth . ', ';
+		$js .= 'overlibwidth:' . $this->overlibwidth . ', ';
+		$js .= 'overlibheight:' . $this->overlibheight . ', ';
 
 		if (preg_match('/^(none|nink|inpie|outpie|box|rbox|gauge|round)$/', $this->iconfile)) {
 			$js .= 'iconfile:' . js_escape('::' . $this->iconfile);
@@ -1011,8 +1011,8 @@ class WeatherMapNode extends WeatherMapItem {
 			$js .= '"overliburl":' . js_escape($this->overliburl) . ', ';
 			$js .= '"overlibcaption":' . js_escape($this->overlibcaption) . ', ';
 
-			$js .= '"overlibwidth":' . $this->overlibheight . ', ';
-			$js .= '"overlibheight":' . $this->overlibwidth . ', ';
+			$js .= '"overlibwidth":' . $this->overlibwidth . ', ';
+			$js .= '"overlibheight":' . $this->overlibheight . ', ';
 			$js .= '"iconfile":' . js_escape($this->iconfile) . ', ';
 		}
 

--- a/lib/editor.inc.php
+++ b/lib/editor.inc.php
@@ -543,7 +543,7 @@ function handle_inheritance(&$map, &$inheritables) {
 			if ($inheritable[0] == 'node') {
 				$map->nodes['DEFAULT']->$fieldname = $new;
 
-				foreach ($map->nodes as $link_name => $node) {
+				foreach ($map->nodes as $node_name => $node) {
 					if ($node->name != ':: DEFAULT ::' && $old == $node->$fieldname) {
 						$map->nodes[$node->name]->$fieldname = $new;
 					}

--- a/weathermap-cacti-plugin.php
+++ b/weathermap-cacti-plugin.php
@@ -86,7 +86,7 @@ switch (get_request_var('action')) {
 					// readfile_chunked($imagefile);
 					readfile($imagefile);
 
-					dir($orig_cwd);
+					chdir($orig_cwd);
 				} else {
 					// no permission to view this map
 				}
@@ -128,7 +128,7 @@ switch (get_request_var('action')) {
 					$map->ReadData();
 					$map->DrawMap('', '', 250, true, false);
 
-					dir($orig_cwd);
+					chdir($orig_cwd);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Fix swapped `overlibwidth`/`overlibheight` values in `asJS()` and `asJSON()` for links and nodes
- Fix `array_merge` + `array_slice($newpoints, 1)` for curve-point arrays: the previous union operator dropped key 0 (the previous control point needed for the next span calculation), causing malformed curves on multi-span links
- Fix swapped `preg_replace` arguments in `%k` format handler; use `preg_replace_callback` with `preg_quote($spec, '/')` to prevent backreference expansion and dot-matches-any
- Fix `$joinchar` assignment: dash flag now sets `'-'`, not `' '`
- Fix `$this->configFile` → `$this->configfile` (PHP property name case)
- Fix legend drawing: all drawing coordinates inside `$scale_im` use local (0,0)-based coords; `$boxx`/`$boxy` are the map-level copy destination, not the draw origin
- Remove dead `return 0` at top of `LoadCoverage()` that suppressed all file I/O; add path guard and `explode` count check; add matching path-traversal guard to `SaveCoverage()`
- Fix `gdref1` hardcoded key → `$scale_ref` in `DrawLegend_Vertical`; add `isset()` guards on `KEYTEXT[$scale_ref]`
- Fix `strchr != false` → `!== false` in header injection check
- Fix iterator variable `$link_name` → `$node_name` in `editor.inc.php`

## Test plan

- [ ] Render a map with links that have `overlibwidth`/`overlibheight` set and verify tooltip dimensions are correct
- [ ] Render a map with a multi-span curved link and verify no backwards segment appears
- [ ] Render a map with a gradient scale and verify the legend box, outline, and text render at the correct legend position (not clipped to map (0,0))
- [ ] Confirm maps with `%k` bandwidth formatting display correct values
- [ ] Load and save a coverage file; verify file is read and written within the plugin base directory
- [ ] Open editor and verify node iterator does not mix up node/link names