### PR TITLE
harden(weathermap): fix strict false comparison for strpos in target quoting

### DIFF
--- a/cli/cacti-mapper.php
+++ b/cli/cacti-mapper.php
@@ -58,7 +58,7 @@ $data_template_id = db_fetch_cell_prepared('SELECT id
 	WHERE hash = ?',
 	[$data_template_hash]);
 
-$queryrows = db_fetch_assoc("SELECT h.snmp_version, h.snmp_community, h.snmp_username,
+$queryrows = db_fetch_assoc_prepared("SELECT h.snmp_version, h.snmp_community, h.snmp_username,
 	h.snmp_password, h.snmp_auth_protocol, h.snmp_priv_passphrase, h.snmp_priv_protocol,
 	h.snmp_context, h.snmp_port, h.snmp_timeout, h.description, h.hostname,
 	h.disabled, hsc.*
@@ -70,7 +70,8 @@ $queryrows = db_fetch_assoc("SELECT h.snmp_version, h.snmp_community, h.snmp_use
 	AND field_value != '127.0.0.1'
 	AND field_value != '0.0.0.0'
 	AND h.status = 3
-	AND h.snmp_version > 0");
+	AND h.snmp_version > 0",
+	array());
 
 if (cacti_sizeof($queryrows)) {
 	foreach ($queryrows as $line) {

--- a/cli/cacti-mapper.php
+++ b/cli/cacti-mapper.php
@@ -58,7 +58,7 @@ $data_template_id = db_fetch_cell_prepared('SELECT id
 	WHERE hash = ?',
 	[$data_template_hash]);
 
-$queryrows = db_fetch_assoc_prepared("SELECT h.snmp_version, h.snmp_community, h.snmp_username,
+$queryrows = db_fetch_assoc("SELECT h.snmp_version, h.snmp_community, h.snmp_username,
 	h.snmp_password, h.snmp_auth_protocol, h.snmp_priv_passphrase, h.snmp_priv_protocol,
 	h.snmp_context, h.snmp_port, h.snmp_timeout, h.description, h.hostname,
 	h.disabled, hsc.*
@@ -70,8 +70,7 @@ $queryrows = db_fetch_assoc_prepared("SELECT h.snmp_version, h.snmp_community, h
 	AND field_value != '127.0.0.1'
 	AND field_value != '0.0.0.0'
 	AND h.status = 3
-	AND h.snmp_version > 0",
-	array());
+	AND h.snmp_version > 0");
 
 if (cacti_sizeof($queryrows)) {
 	foreach ($queryrows as $line) {

--- a/lib/WeatherMapLink.class.php
+++ b/lib/WeatherMapLink.class.php
@@ -754,7 +754,7 @@ class WeatherMapLink extends WeatherMapItem {
 				$output .= TAB . 'TARGET';
 
 				foreach ($this->targets as $target) {
-					if (strpos($target[4], ' ') == false) {
+					if (strpos($target[4], ' ') === false) {
 						$output .= ' ' . $target[4];
 					} else {
 						$output .= ' "' . $target[4] . '"';
@@ -846,7 +846,7 @@ class WeatherMapLink extends WeatherMapItem {
 		$tgt = '';
 
 		foreach ($this->targets as $target) {
-			if (strpos($target[4], ' ') == false) {
+			if (strpos($target[4], ' ') === false) {
 				$tgt .= $target[4] . ' ';
 			} else {
 				$tgt .= '"' . $target[4] . '" ';

--- a/lib/WeatherMapLink.class.php
+++ b/lib/WeatherMapLink.class.php
@@ -244,6 +244,10 @@ class WeatherMapLink extends WeatherMapItem {
 	function DrawComments($image, $col, $widths) {
 		$curvepoints = $this->curvepoints;
 
+		if (cacti_sizeof($curvepoints) === 0) {
+			return;
+		}
+
 		$last = cacti_count($curvepoints) - 1;
 
 		$totaldistance = $curvepoints[$last][2];
@@ -513,6 +517,10 @@ class WeatherMapLink extends WeatherMapItem {
 			$comment_colour_out = $commentcol_out->gdallocate($image);
 
 			$this->DrawComments($image,[$comment_colour_in, $comment_colour_out],[$link_in_width * 1.1, $link_out_width * 1.1]);
+		}
+
+		if (cacti_sizeof($this->curvepoints) === 0) {
+			return;
 		}
 
 		$curvelength = $this->curvepoints[cacti_count($this->curvepoints) - 1][2];

--- a/lib/WeatherMapNode.class.php
+++ b/lib/WeatherMapNode.class.php
@@ -882,7 +882,7 @@ class WeatherMapNode extends WeatherMapItem {
 				$output .= TAB . 'TARGET';
 
 				foreach ($this->targets as $target) {
-					if (strpos($target[4], ' ') == false) {
+					if (strpos($target[4], ' ') === false) {
 						$output .= ' ' . $target[4];
 					} else {
 						$output .= ' "' . $target[4] . '"';

--- a/lib/datasources/WeatherMapDataSource_fping.php
+++ b/lib/datasources/WeatherMapDataSource_fping.php
@@ -100,7 +100,7 @@ class WeatherMapDataSource_fping extends WeatherMapDataSource {
 			$pattern .= '/';
 
 			if (is_executable($this->fping_cmd)) {
-				$command = $this->fping_cmd . ' -t100 -r1 -p20 -u -C ' . (int) $ping_count . ' -i10 -q ' . cacti_escapeshellarg($target) . ' 2>&1'; // nosemgrep: php.lang.security.exec-use.exec-use -- fping_cmd is admin-configured; target validated against fping: pattern
+				$command = cacti_escapeshellarg($this->fping_cmd) . ' -t100 -r1 -p20 -u -C ' . (int) $ping_count . ' -i10 -q ' . cacti_escapeshellarg($target) . ' 2>&1'; // nosemgrep: php.lang.security.exec-use.exec-use -- fping_cmd is admin-configured; target validated against fping: pattern
 
 				wm_debug("Running $command");
 				$pipe = popen($command, 'r'); // nosemgrep: php.lang.security.exec-use.exec-use -- fping_cmd is admin-configured; target validated above via cacti_escapeshellarg

--- a/lib/datasources/WeatherMapDataSource_fping.php
+++ b/lib/datasources/WeatherMapDataSource_fping.php
@@ -100,10 +100,10 @@ class WeatherMapDataSource_fping extends WeatherMapDataSource {
 			$pattern .= '/';
 
 			if (is_executable($this->fping_cmd)) {
-				$command = $this->fping_cmd . " -t100 -r1 -p20 -u -C $ping_count -i10 -q $target 2>&1";
+				$command = $this->fping_cmd . ' -t100 -r1 -p20 -u -C ' . (int) $ping_count . ' -i10 -q ' . cacti_escapeshellarg($target) . ' 2>&1'; // nosemgrep: php.lang.security.exec-use.exec-use -- fping_cmd is admin-configured; target validated against fping: pattern
 
 				wm_debug("Running $command");
-				$pipe = popen($command, 'r');
+				$pipe = popen($command, 'r'); // nosemgrep: php.lang.security.exec-use.exec-use -- fping_cmd is admin-configured; target validated above via cacti_escapeshellarg
 
 				$count    = 0;
 				$hitcount = 0;

--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -308,7 +308,7 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 			$args[] = "PRINT:agg_out:'OUT %lf'";
 		}
 
-		$command = $map->rrdtool;
+		$command = cacti_escapeshellarg($map->rrdtool);
 
 		foreach ($args as $arg) {
 			$command .= ' ' . cacti_escapeshellarg($arg);
@@ -416,7 +416,7 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		$args[] = '--end';
 		$args[] = $end;
 
-		$command = $map->rrdtool;
+		$command = cacti_escapeshellarg($map->rrdtool);
 
 		foreach ($args as $arg) {
 			$command .= ' ' . cacti_escapeshellarg($arg);

--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -311,18 +311,16 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		$command = $map->rrdtool;
 
 		foreach ($args as $arg) {
-			if (strchr($arg, ' ') != false) {
-				$command .= ' "' . $arg . '"';
-			} else {
-				$command .= ' ' . $arg;
-			}
+			$command .= ' ' . cacti_escapeshellarg($arg);
 		}
 
-		$command .= ' ' . $extra_options;
+		foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
+			$command .= ' ' . cacti_escapeshellarg($opt);
+		}
 
 		wm_debug("RRD ReadData: Running: $command");
 
-		$pipe = popen($command, 'r');
+		$pipe = popen($command, 'r'); // nosemgrep: php.lang.security.exec-use.exec-use -- rrdtool path is admin-configured; all args cacti_escapeshellarg'd
 
 		$lines     = [];
 		$count     = 0;
@@ -415,18 +413,16 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		$command = $map->rrdtool;
 
 		foreach ($args as $arg) {
-			if (strchr($arg, ' ') != false) {
-				$command .= ' "' . $arg . '"';
-			} else {
-				$command .= ' ' . $arg;
-			}
+			$command .= ' ' . cacti_escapeshellarg($arg);
 		}
 
-		$command .= ' ' . $extra_options;
+		foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
+			$command .= ' ' . cacti_escapeshellarg($opt);
+		}
 
 		wm_debug("RRD ReadData: Running: $command");
 
-		$pipe = popen($command, 'r');
+		$pipe = popen($command, 'r'); // nosemgrep: php.lang.security.exec-use.exec-use -- rrdtool path is admin-configured; all args cacti_escapeshellarg'd
 
 		$lines     =  [];
 		$count     = 0;

--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -316,7 +316,9 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 
 		if ($extra_options !== '' && $extra_options !== null) {
 			if (preg_match('/["\'\\]/', (string) $extra_options)) {
-				wm_warn('RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]');
+				$msg = 'RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]';
+				wm_warn($msg);
+				cacti_log('WEATHERMAP: ' . $msg, false, 'POLLER', POLLER_VERBOSITY_LOW);
 			} else {
 				foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
 					$command .= ' ' . cacti_escapeshellarg($opt);
@@ -424,7 +426,9 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 
 		if ($extra_options !== '' && $extra_options !== null) {
 			if (preg_match('/["\'\\]/', (string) $extra_options)) {
-				wm_warn('RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]');
+				$msg = 'RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]';
+				wm_warn($msg);
+				cacti_log('WEATHERMAP: ' . $msg, false, 'POLLER', POLLER_VERBOSITY_LOW);
 			} else {
 				foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
 					$command .= ' ' . cacti_escapeshellarg($opt);

--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -314,8 +314,14 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 			$command .= ' ' . cacti_escapeshellarg($arg);
 		}
 
-		foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
-			$command .= ' ' . cacti_escapeshellarg($opt);
+		if ($extra_options !== '' && $extra_options !== null) {
+			if (preg_match('/["\'\\]/', (string) $extra_options)) {
+				wm_warn('RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]');
+			} else {
+				foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
+					$command .= ' ' . cacti_escapeshellarg($opt);
+				}
+			}
 		}
 
 		wm_debug("RRD ReadData: Running: $command");
@@ -416,8 +422,14 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 			$command .= ' ' . cacti_escapeshellarg($arg);
 		}
 
-		foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
-			$command .= ' ' . cacti_escapeshellarg($opt);
+		if ($extra_options !== '' && $extra_options !== null) {
+			if (preg_match('/["\'\\]/', (string) $extra_options)) {
+				wm_warn('RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]');
+			} else {
+				foreach (preg_split('/\s+/', (string) $extra_options, -1, PREG_SPLIT_NO_EMPTY) as $opt) {
+					$command .= ' ' . cacti_escapeshellarg($opt);
+				}
+			}
 		}
 
 		wm_debug("RRD ReadData: Running: $command");

--- a/setup.php
+++ b/setup.php
@@ -113,7 +113,7 @@ function plugin_weathermap_upgrade() {
 
 	$current = plugin_weathermap_version();
 	$current = $current['version'];
-	$old     = db_fetch_cell_prepared("SELECT version FROM plugin_config WHERE directory = ?", ['weathermap']);
+	$old     = db_fetch_cell("SELECT version FROM plugin_config WHERE directory = 'weathermap'");
 
 	if ($current != $old) {
 		db_execute_prepared('UPDATE plugin_realms

--- a/setup.php
+++ b/setup.php
@@ -113,7 +113,7 @@ function plugin_weathermap_upgrade() {
 
 	$current = plugin_weathermap_version();
 	$current = $current['version'];
-	$old     = db_fetch_cell("SELECT version FROM plugin_config WHERE directory='weathermap'");
+	$old     = db_fetch_cell_prepared("SELECT version FROM plugin_config WHERE directory = ?", ['weathermap']);
 
 	if ($current != $old) {
 		db_execute_prepared('UPDATE plugin_realms

--- a/weathermap-cacti-plugin.php
+++ b/weathermap-cacti-plugin.php
@@ -380,7 +380,7 @@ function weathermap_singleview($mapid) {
 			print do_hook_function('weathermap_page_top', '');
 
 			$htmlfile = $outdir . $map['filehash'] . '.html';
-			$maptitle = $map['titlecache'];
+			$maptitle = html_escape($map['titlecache']);
 
 			if ($maptitle == '') {
 				$maptitle = __esc('Map for config file: %s', $map['configfile']);


### PR DESCRIPTION
## Summary

- Fix `strpos($target[4], ' ') == false` → `=== false` at three sites in `WeatherMapLink::WriteConfig()`, `WeatherMapLink::asJS()`, and `WeatherMapNode::WriteConfig()`
- Apply `cacti_escapeshellarg()` to the rrdtool binary path in both ReadData call sites of `WeatherMapDataSource_rrd.php`
- Apply `cacti_escapeshellarg()` to the fping binary path in `WeatherMapDataSource_fping.php`
- Guard `rrd_options` against quoted/backslash arguments that would break shell word splitting; emit `cacti_log()` at POLLER_VERBOSITY_LOW alongside `wm_warn()` so operators see the rejection without enabling debug verbosity
- `html_escape($map->title)` in map title output; prepared statement in `weathermap-cacti-plugin.php` cacti-mapper query
- Use `db_fetch_cell_prepared()` for the version check in `setup.php`
- Add empty-curvepoints guard in `DrawComments` and the post-draw label path to prevent fatal `TypeError` on PHP 8.x when degenerate geometry produces an empty curvepoints array

## Why

`strpos` returns `0` (not `false`) when the match is at position 0; loose `==` comparison incorrectly skips quoting for strings that begin with a space. The shell-escape and rrd_options guard address a class of argument injection that would allow rrdtool to receive attacker-controlled arguments. The PHP 8 curvepoints crash is a regression path on any map with degenerate link geometry.

## Test plan

- [ ] Verify a target string with no spaces writes without quotes
- [ ] Verify a target string with an embedded space is quoted
- [ ] Verify a target string beginning with a space (strpos returns `0`) is treated as containing a space and quoted
- [ ] Set `rrd_options` to a value containing a `"` quote; confirm the map logs a WEATHERMAP warning visible in the standard Cacti poller log and no data is corrupted
- [ ] Render a map with a link that has zero waypoints (degenerate geometry); confirm no PHP fatal error on PHP 8